### PR TITLE
Add shape loader example

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,14 +47,14 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.6.0'
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.7.6'
 
-    implementation 'androidx.graphics:graphics-shapes:1.0.0-alpha03'
+    implementation 'androidx.graphics:graphics-shapes:1.0.0-alpha04'
     def composeBom = platform("dev.chrisbanes.compose:compose-bom:2023.07.00-alpha01")
     implementation "androidx.compose.ui:ui-util"
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'androidx.activity:activity-compose:1.8.2'
     implementation composeBom
 
     implementation 'androidx.compose.animation:animation-graphics'
@@ -64,13 +64,13 @@ dependencies {
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'io.coil-kt:coil-compose:2.4.0'
-    implementation "androidx.navigation:navigation-compose:2.7.0-beta02"
+    implementation "androidx.navigation:navigation-compose:2.7.6"
     implementation "com.google.accompanist:accompanist-pager-indicators:0.29.1-alpha"
-    implementation "androidx.graphics:graphics-shapes:1.0.0-alpha03"
+    implementation "androidx.graphics:graphics-shapes:1.0.0-alpha04"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2022.11.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2023.10.01')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
+++ b/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
@@ -98,28 +98,23 @@ fun ShapeAsLoader() {
                 val totalLength = pathMeasurer.length
 
                 onDrawBehind {
+
                     rotate(rotation.value) {
                         translate(size.width / 2f, size.height / 2f) {
+                            val brush = Brush.sweepGradient(colors, center = Offset(0.5f, 0.5f))
+
                             val currentLength = totalLength * progress.value
                             flattenedStarPath.forEach { line ->
-                                val startColor = interpolateColors(line.startFraction, colors)
                                 if (line.startFraction * totalLength < currentLength) {
                                     if (progress.value > line.endFraction) {
-                                        val endColor = interpolateColors(line.endFraction, colors)
                                         drawLine(
-                                            brush = Brush.linearGradient(
-                                                listOf(
-                                                    startColor,
-                                                    endColor
-                                                )
-                                            ),
+                                            brush = brush,
                                             start = Offset(line.start.x, line.start.y),
                                             end = Offset(line.end.x, line.end.y),
                                             strokeWidth = 16.dp.toPx(),
                                             cap = StrokeCap.Round
                                         )
                                     } else {
-                                        val endColor = interpolateColors(progress.value, colors)
                                         val endX = mapValue(
                                             progress.value,
                                             line.startFraction,
@@ -135,12 +130,7 @@ fun ShapeAsLoader() {
                                             line.end.y
                                         )
                                         drawLine(
-                                            brush = Brush.linearGradient(
-                                                listOf(
-                                                    startColor,
-                                                    endColor
-                                                )
-                                            ),
+                                            brush =brush,
                                             start = Offset(line.start.x, line.start.y),
                                             end = Offset(endX, endY),
                                             strokeWidth = 16.dp.toPx(),
@@ -155,18 +145,6 @@ fun ShapeAsLoader() {
             }
             .fillMaxSize()
     )
-}
-
-private fun interpolateColors(
-    progress: Float,
-    colorsInput: List<Color>,
-): Color {
-    if (progress == 1f) return colorsInput.last()
-    val scaledProgress = progress * (colorsInput.size - 1)
-    val oldColor = colorsInput[scaledProgress.toInt()]
-    val newColor = colorsInput[(scaledProgress + 1f).toInt()]
-    val newScaledAnimationValue = scaledProgress - floor(scaledProgress)
-    return lerp(start = oldColor, stop = newColor, fraction = newScaledAnimationValue)
 }
 
 private val colors = listOf(

--- a/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
+++ b/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
@@ -1,0 +1,212 @@
+package dev.riggaroo.composeplaytime
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.asAndroidPath
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.flatten
+import androidx.graphics.shapes.CornerRounding
+import androidx.graphics.shapes.Cubic
+import androidx.graphics.shapes.Morph
+import androidx.graphics.shapes.RoundedPolygon
+import androidx.graphics.shapes.circle
+import androidx.graphics.shapes.star
+import kotlin.math.absoluteValue
+import kotlin.math.floor
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Preview
+@Composable
+fun ShapeAsLoader() {
+    // [START android_compose_graphics_basic_polygon]
+    val infiniteTransition = rememberInfiniteTransition(label = "infinite")
+    val progress = infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            tween(4000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "progress"
+    )
+    val rotation = infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            tween(4000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "rotation"
+    )
+    val pathMeasurer = remember {
+        PathMeasure()
+    }
+    Box(
+        modifier = Modifier
+            .padding(16.dp)
+            .drawWithCache {
+                val starPolygon = RoundedPolygon.star(
+                    numVerticesPerRadius = 12,
+                    innerRadius = size.minDimension / 3f,
+                    rounding = CornerRounding(size.minDimension / 6f),
+                    radius = size.minDimension / 2,
+                    centerX = size.width / 2,
+                    centerY = size.height / 2,
+
+                    )
+                val roundedPolygon = RoundedPolygon.circle(
+                    numVertices = 12,
+                    radius = size.minDimension / 2,
+                    centerX = size.width / 2,
+                    centerY = size.height / 2
+                )
+                val morph = Morph(starPolygon, roundedPolygon)
+
+                val moprhPath = morph.toComposePath(progress = progress.value)
+                val morphAndroidPath = moprhPath
+                    .asAndroidPath()
+                val flattenedStarPath = morphAndroidPath.flatten()
+
+                pathMeasurer.setPath(moprhPath, false)
+                val totalLength = pathMeasurer.length
+
+                onDrawBehind {
+                    rotate(rotation.value) {
+                        val currentLength = totalLength * progress.value
+                        flattenedStarPath.forEach { line ->
+                            val startColor = interpolateColors(line.startFraction, colors)
+                            if (line.startFraction * totalLength < currentLength) {
+                                if (progress.value > line.endFraction) {
+                                    val endColor = interpolateColors(line.endFraction, colors)
+                                    drawLine(
+                                        brush = Brush.linearGradient(listOf(startColor, endColor)),
+                                        start = Offset(line.start.x, line.start.y),
+                                        end = Offset(line.end.x, line.end.y),
+                                        strokeWidth = 16.dp.toPx(),
+                                        cap = StrokeCap.Round
+                                    )
+                                } else {
+                                    val endColor = interpolateColors(progress.value, colors)
+                                    val endX = mapValue(
+                                        progress.value,
+                                        line.startFraction,
+                                        line.endFraction,
+                                        line.start.x,
+                                        line.end.x
+                                    )
+                                    val endY = mapValue(
+                                        progress.value,
+                                        line.startFraction,
+                                        line.endFraction,
+                                        line.start.y,
+                                        line.end.y
+                                    )
+                                    drawLine(
+                                        brush = Brush.linearGradient(listOf(startColor, endColor)),
+                                        start = Offset(line.start.x, line.start.y),
+                                        end = Offset(endX.absoluteValue, endY.absoluteValue),
+                                        strokeWidth = 16.dp.toPx(),
+                                        cap = StrokeCap.Round
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                }
+            }
+            .fillMaxSize()
+    )
+    // [END android_compose_graphics_basic_polygon]
+}
+
+private fun interpolateColors(
+    progress: Float,
+    colorsInput: List<Color>,
+): Color {
+    if (progress == 1f) return colorsInput.last()
+    val scaledProgress = progress * (colorsInput.size - 1)
+    val oldColor = colorsInput[scaledProgress.toInt()]
+    val newColor = colorsInput[(scaledProgress + 1f).toInt()]
+    val newScaledAnimationValue = scaledProgress - floor(scaledProgress)
+    return lerp(start = oldColor, stop = newColor, fraction = newScaledAnimationValue)
+}
+
+private val colors = listOf(
+    Color(0xFF3FCEBC),
+    Color(0xFF3CBCEB),
+    Color(0xFF5F96E7),
+    Color(0xFF816FE3),
+    Color(0xFF9F5EE2),
+    Color(0xFFBD4CE0),
+    Color(0xFFDE589F),
+    Color(0xFF3FCEBC),
+)
+
+private fun mapValue(
+    value: Float,
+    fromRangeStart: Float,
+    fromRangeEnd: Float,
+    toRangeStart: Float,
+    toRangeEnd: Float
+): Float {
+    val ratio =
+        (value - fromRangeStart) / (fromRangeEnd - fromRangeStart)
+    return toRangeStart + ratio * (toRangeEnd - toRangeStart)
+}
+
+fun List<Cubic>.toPath(path: Path = Path(), scale: Float = 1f): Path {
+    path.rewind()
+    firstOrNull()?.let { first ->
+        path.moveTo(first.anchor0X * scale, first.anchor0Y * scale)
+    }
+    for (bezier in this) {
+        path.cubicTo(
+            bezier.control0X * scale, bezier.control0Y * scale,
+            bezier.control1X * scale, bezier.control1Y * scale,
+            bezier.anchor1X * scale, bezier.anchor1Y * scale
+        )
+    }
+    path.close()
+    return path
+}
+
+fun Morph.toComposePath(progress: Float, scale: Float = 1f, path: Path = Path()): Path {
+    var first = true
+    path.rewind()
+    forEachCubic(progress) { bezier ->
+        if (first) {
+            path.moveTo(bezier.anchor0X * scale, bezier.anchor0Y * scale)
+            first = false
+        }
+        path.cubicTo(
+            bezier.control0X * scale, bezier.control0Y * scale,
+            bezier.control1X * scale, bezier.control1Y * scale,
+            bezier.anchor1X * scale, bezier.anchor1Y * scale
+        )
+    }
+    path.close()
+    return path
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.2.0-alpha03' apply false
+    id 'com.android.application' version '8.2.0' apply false
     id 'com.android.library' version '8.1.0-alpha09' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Dec 07 16:39:45 GMT 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Using `graphics-shapes`, we can create fun effects using `Path#flatten()`

![final_result-ezgif com-resize](https://github.com/riggaroo/compose-playtime/assets/9973046/d3d0ac5f-561c-4781-aa49-58c5f0f7d7e2)

