### PR TITLE
Remove custom usage of toComposePath

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,13 +48,13 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.7.6'
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.7.7'
 
-    implementation 'androidx.graphics:graphics-shapes:1.0.0-alpha04'
-    def composeBom = platform("dev.chrisbanes.compose:compose-bom:2023.07.00-alpha01")
+    implementation 'androidx.graphics:graphics-shapes:1.0.0-alpha06'
+    def composeBom = platform("androidx.compose:compose-bom:2024.02.02")
     implementation "androidx.compose.ui:ui-util"
     implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation composeBom
 
@@ -64,14 +64,14 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.compose.material:material-icons-extended'
-    implementation 'io.coil-kt:coil-compose:2.4.0'
-    implementation "androidx.navigation:navigation-compose:2.7.6"
+    implementation 'io.coil-kt:coil-compose:2.5.0'
+    implementation "androidx.navigation:navigation-compose:2.7.7"
     implementation "com.google.accompanist:accompanist-pager-indicators:0.29.1-alpha"
-    implementation "androidx.graphics:graphics-shapes:1.0.0-alpha04"
+    implementation "androidx.graphics:graphics-shapes:1.0.0-alpha05"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2023.10.01')
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.02.02')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
+++ b/app/src/main/java/dev/riggaroo/composeplaytime/ShapeLoaderDemo.kt
@@ -87,6 +87,9 @@ fun ShapeAsLoader() {
     var androidPath = remember {
         android.graphics.Path()
     }
+    val matrix = remember {
+        Matrix()
+    }
 
     Box(
         modifier = Modifier
@@ -95,7 +98,6 @@ fun ShapeAsLoader() {
                 // We first convert to an android.graphics.Path, then to compose Path.
                 androidPath = morph.toPath(progress.value, androidPath)
                 morphPath = androidPath.asComposePath()
-                val matrix = Matrix()
                 matrix.reset()
                 matrix.scale(size.minDimension / 2f, size.minDimension / 2f)
                 morphPath.transform(matrix)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.3.0-alpha02' apply false
+    id 'com.android.application' version '8.3.0' apply false
     id 'com.android.library' version '8.1.0-alpha09' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Dec 07 16:39:45 GMT 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In favour of Android equivalent - `toPath().toComposePath()`